### PR TITLE
[feat] 에러 바운더리 추가

### DIFF
--- a/src/app/provider/RootErrorBoundary.tsx
+++ b/src/app/provider/RootErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, ReactNode } from "react";
+
+import { RootErrorModal } from "@widgets/error/ui/RootErrorModal";
+
+import { ErrorBoundaryState } from "@entities/error";
+
+type ErrorBoundaryProps = {
+    children?: ReactNode;
+};
+type RootErrorBoundaryState = Omit<ErrorBoundaryState, "shouldRethrow">;
+
+// 함수형으로 만들려면 라이브러리 다운 필요.
+export class RootErrorBoundary extends Component<ErrorBoundaryProps, RootErrorBoundaryState> {
+    public state: RootErrorBoundaryState = {};
+
+    // Error 캐치시 return 값으로 상태 변경
+    static getDerivedStateFromError({ error }: { error: Error }): RootErrorBoundaryState {
+        return { error: error };
+    }
+    /** 못잡은 에러 잡기. 어떻게 해결할지 논의 필요*/
+    handleUncatchedError = (e: PromiseRejectionEvent): void => {
+        e.preventDefault();
+        if (e.reason instanceof Error) {
+            this.setState({ error: e.reason });
+        }
+    };
+
+    componentDidMount(): void {
+        window.addEventListener("unhandledrejection", this.handleUncatchedError);
+    }
+    componentWillUnmount(): void {
+        window.removeEventListener("unhandledrejection", this.handleUncatchedError);
+    }
+
+    render() {
+        const {
+            props: { children },
+            state: { error },
+        } = this;
+        return (
+            <>
+                {/* 에러 시 에러 모달 or 토스트 출력, 작업하며 나오는 에러들을 보며 어떻게 안잡히는 에러들 띄어줄지 연구필요 */}
+                {error && <RootErrorModal title={error.name} message={error.message} />}
+                {children}
+            </>
+        );
+    }
+}

--- a/src/app/provider/RouterErrorBoundary.tsx
+++ b/src/app/provider/RouterErrorBoundary.tsx
@@ -1,0 +1,23 @@
+import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+
+import { RouterErrorComponent } from "@widgets/error";
+
+/** 라우터 Loader, action 에서 말생하는 에러 잡기
+ * (필요한 데이터를 못받으면 페이지 띄우는 의미가 없기 때문.)
+ * */
+export const RouterErrorBoundary = () => {
+    const error = useRouteError();
+    /** 라우팅에서 발생하는 에러들 */
+    if (isRouteErrorResponse(error)) {
+        switch (error.status) {
+            case 404:
+                return <RouterErrorComponent message="없는 페이지 입니다." />;
+            case 401:
+                return <RouterErrorComponent message="권한이 없습니다." />;
+            case 503:
+                return <RouterErrorComponent message="서버가 다운된 것 같습니다." />;
+            default:
+                return <RouterErrorComponent message="데이터를 제대로 불러오지 못했습니다." />;
+        }
+    }
+};

--- a/src/app/provider/index.ts
+++ b/src/app/provider/index.ts
@@ -1,2 +1,3 @@
 export { Providers } from "./providers";
+export { RootErrorBoundary } from "./RootErrorBoundary";
 export { RouterErrorBoundary } from "./RouterErrorBoundary";

--- a/src/app/provider/index.ts
+++ b/src/app/provider/index.ts
@@ -1,1 +1,2 @@
 export { Providers } from "./providers";
+export { RouterErrorBoundary } from "./RouterErrorBoundary";

--- a/src/app/provider/providers.tsx
+++ b/src/app/provider/providers.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from "@emotion/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
+import { RootErrorBoundary } from "./RootErrorBoundary";
+
 interface ProvidersProps {
     readonly children: ReactNode;
 }
@@ -15,7 +17,7 @@ export function Providers({ children }: ProvidersProps) {
     return (
         <ThemeProvider theme={theme}>
             <QueryClientProvider client={queryClient}>
-                {children}
+                <RootErrorBoundary>{children}</RootErrorBoundary>
                 <ReactQueryDevtools initialIsOpen={false} />
             </QueryClientProvider>
         </ThemeProvider>

--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -1,9 +1,17 @@
-import { Navigate, RouterProvider, createBrowserRouter } from "react-router-dom";
+import { Navigate, RouteObject, RouterProvider, createBrowserRouter } from "react-router-dom";
 
 import { HomePage } from "@pages";
 
+/** DEV환경에서 추가되는 router */
+let DevRouter: RouteObject[];
+if (import.meta.env.DEV) {
+    const { DevRouter: DRouter } = await import("./DevRouter");
+    DevRouter = DRouter;
+}
+
 export function AppRouter() {
     const router = createBrowserRouter([
+        ...(import.meta.env.DEV ? DevRouter : []),
         {
             path: "/",
             element: <HomePage />,

--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -1,5 +1,6 @@
 import { Navigate, RouteObject, RouterProvider, createBrowserRouter } from "react-router-dom";
 
+import { RouterErrorBoundary } from "@app/provider/RouterErrorBoundary";
 import { HomePage } from "@pages";
 
 /** DEV환경에서 추가되는 router */
@@ -15,6 +16,7 @@ export function AppRouter() {
         {
             path: "/",
             element: <HomePage />,
+            errorElement: <RouterErrorBoundary />,
         },
         { path: "*", element: <Navigate to="/" replace /> },
     ]);

--- a/src/app/router/DevRouter.tsx
+++ b/src/app/router/DevRouter.tsx
@@ -1,0 +1,14 @@
+import { RouteObject } from "react-router-dom";
+
+import { ExampleFail, ExampleSuccess } from "@pages/Example";
+
+export const DevRouter: RouteObject[] = [
+    {
+        path: "/example-success",
+        element: <ExampleSuccess />,
+    },
+    {
+        path: "/example-fail",
+        element: <ExampleFail />,
+    },
+];

--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -1,1 +1,2 @@
 export { AppRouter } from "./AppRouter";
+export { DevRouter } from "./DevRouter";

--- a/src/entities/error/index.ts
+++ b/src/entities/error/index.ts
@@ -1,0 +1,3 @@
+export { FetchErrorBoundary } from "./provider/FetchErrorProvider";
+export { getErrorBoundaryState } from "./provider/getErrorBoundaryState";
+export type { ErrorBoundaryState } from "./model/ErrorBoundaryState";

--- a/src/entities/error/model/ErrorBoundaryState.ts
+++ b/src/entities/error/model/ErrorBoundaryState.ts
@@ -1,0 +1,16 @@
+import { AxiosError } from "axios";
+
+/**
+ * @property {"retry" | "reload" | "redirect-Home" | "redirect-Login"} handleType - 다루는 방법
+ *   - "retry": 다시 렌더링
+ *   - "reload": 새로고침
+ *   - "redirect-Home": 홈으로 이동
+ *   - "redirect-Login": 로그인으로 이동
+ *   - "back": 뒤로가기
+ * @property {boolean} shouldRethrow - 다시 throw 하여 상위 바운더리로 보내기
+ */
+export type ErrorBoundaryState = {
+    error?: Error | AxiosError;
+    handleType?: "retry" | "reload" | "redirect-Home" | "redirect-Login" | "back";
+    shouldRethrow: boolean;
+};

--- a/src/entities/error/provider/FetchErrorProvider.tsx
+++ b/src/entities/error/provider/FetchErrorProvider.tsx
@@ -1,0 +1,98 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+
+import { ErrorBoundaryState } from "../model/ErrorBoundaryState";
+import { getErrorBoundaryState } from "./getErrorBoundaryState";
+
+type ErrorBoundaryProps = {
+    children?: ReactNode;
+};
+
+/**
+ * 에러 바운더리
+ * 하위 트리에서 throw한 에러를 처리하는 코드
+ * 컴포넌트 단위 전용.
+ */
+export class FetchErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    public state: ErrorBoundaryState = { shouldRethrow: false };
+
+    /** 에러 Catch시 실행하는 함수 return값이 state가 됨.
+     * componentDidCatch보다 먼저 실행 됨
+     */
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return getErrorBoundaryState(error);
+    }
+
+    // 에러 캐치후 상태 바뀐 뒤 실행 함수.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+        if (this.state.shouldRethrow) {
+            throw error;
+        }
+    }
+
+    /** 다시 렌더링시키는 함수 */
+    public handleRetry = () => {
+        this.setState({ error: undefined, shouldRethrow: false });
+    };
+
+    render() {
+        const { children } = this.props;
+        const { error, handleType } = this.state;
+
+        if (error) {
+            /** 디자인 나오면 컴포넌트 분리 및 styled 적용 */
+            return (
+                <div>
+                    <h1>{error.name}</h1>
+                    <h3>{error.message}</h3>
+                    {(() => {
+                        switch (handleType) {
+                            case "retry":
+                                return <button onClick={this.handleRetry}>다시 시도</button>;
+                            case "reload":
+                                return (
+                                    <button onClick={() => window.location.reload()}>
+                                        새로고침
+                                    </button>
+                                );
+                            case "back":
+                                return (
+                                    <button onClick={() => window.history.back()}>뒤로가기</button>
+                                );
+                            case "redirect-Home":
+                                return (
+                                    <button
+                                        onClick={() =>
+                                            window.history.pushState(
+                                                {},
+                                                "",
+                                                `${window.location.origin}/home`
+                                            )
+                                        }
+                                    >
+                                        홈으로 이동
+                                    </button>
+                                );
+                            case "redirect-Login":
+                                return (
+                                    <button
+                                        onClick={() =>
+                                            window.history.pushState(
+                                                {},
+                                                "",
+                                                `${window.location.origin}/login`
+                                            )
+                                        }
+                                    >
+                                        로그인 하기
+                                    </button>
+                                );
+                        }
+                    })()}
+                </div>
+            );
+        }
+
+        return children;
+    }
+}

--- a/src/entities/error/provider/getErrorBoundaryState.ts
+++ b/src/entities/error/provider/getErrorBoundaryState.ts
@@ -1,0 +1,62 @@
+import { isAxiosError } from "axios";
+
+import { ErrorBoundaryState } from "../model/ErrorBoundaryState";
+
+export const getErrorBoundaryState = (error: Error): ErrorBoundaryState => {
+    if (isAxiosError(error)) {
+        switch (error.status) {
+            /** 400 - 형식에 맞지 않은 api 사용 */
+            /** 401 - 인증 실패 */
+            /** 서버 메시지를 보여줌. */
+            case 400:
+            case 401:
+                return {
+                    handleType: "retry",
+                    shouldRethrow: false,
+                    error: { name: error.name, message: error.message },
+                };
+            /** 토큰은 존재하지만 권한이 없음. */
+            case 403:
+                return {
+                    handleType: "back",
+                    shouldRethrow: false,
+                    error: { name: "접근 권한이 업습니다.", message: "관리자에게 문의해보세요." },
+                };
+            /** 404 - 존재하지 않는 리소스 */
+            case 404:
+                return {
+                    handleType: "reload",
+                    shouldRethrow: false,
+                    error: {
+                        name: "존재하지 않는 데이터입니다.",
+                        message: "존재하지 않는 데이터입니다. 새로고침해 주세요.",
+                    },
+                };
+            /** 500 - 서버에서 */
+            /** 기타 에러 */
+            case 500:
+            default:
+                return {
+                    handleType: "retry",
+                    shouldRethrow: false,
+                    error: {
+                        name: "시스템 오류가 발생했습니다.",
+                        message: "문제 해결을 위해 노력하고 있습니다.\n잠시 후 다시 시도해주세요.",
+                    },
+                };
+        }
+    }
+
+    /**
+     * 알려지지 않은 에러
+     * shouldRethrow 여부에 대한 근거가 필요.(코딩 하면서 보완)
+     */
+    return {
+        handleType: "retry",
+        shouldRethrow: false,
+        error: {
+            name: "알 수 없는 에러가 발생했습니다.",
+            message: "알 수 없는 에러가 서버로 전송되었습니다. 잠시 후 다시 시도해주세요.",
+        },
+    };
+};

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,2 +1,3 @@
 export { queryKeys } from "./queryKeys";
 export type { QueryKeys } from "./queryKeys";
+export * from "./error";

--- a/src/pages/Example/index.ts
+++ b/src/pages/Example/index.ts
@@ -1,0 +1,2 @@
+export { ExampleFail } from "./ui/ExampleFail";
+export { ExampleSuccess } from "./ui/ExampleSuccess";

--- a/src/pages/Example/ui/ExampleFail.tsx
+++ b/src/pages/Example/ui/ExampleFail.tsx
@@ -1,0 +1,7 @@
+export const ExampleFail = () => {
+    return (
+        <div>
+            <div>테스트 페이지</div>
+        </div>
+    );
+};

--- a/src/pages/Example/ui/ExampleFail.tsx
+++ b/src/pages/Example/ui/ExampleFail.tsx
@@ -1,7 +1,18 @@
+import { Suspense } from "react";
+
+import { ExampleFetchComponent } from "@widgets/example";
+
+import { FetchErrorBoundary } from "@entities/error";
+
 export const ExampleFail = () => {
     return (
         <div>
             <div>테스트 페이지</div>
+            <FetchErrorBoundary>
+                <Suspense fallback={<div>로딩중...</div>}>
+                    <ExampleFetchComponent isSuccess={false} />
+                </Suspense>
+            </FetchErrorBoundary>
         </div>
     );
 };

--- a/src/pages/Example/ui/ExampleSuccess.tsx
+++ b/src/pages/Example/ui/ExampleSuccess.tsx
@@ -1,7 +1,18 @@
+import { Suspense } from "react";
+
+import { ExampleFetchComponent } from "@widgets/example";
+
+import { FetchErrorBoundary } from "@entities/error";
+
 export const ExampleSuccess = () => {
     return (
         <div>
             <div>테스트 페이지</div>
+            <FetchErrorBoundary>
+                <Suspense fallback={<div>로딩중...</div>}>
+                    <ExampleFetchComponent isSuccess={true} />
+                </Suspense>
+            </FetchErrorBoundary>
         </div>
     );
 };

--- a/src/pages/Example/ui/ExampleSuccess.tsx
+++ b/src/pages/Example/ui/ExampleSuccess.tsx
@@ -1,0 +1,7 @@
+export const ExampleSuccess = () => {
+    return (
+        <div>
+            <div>테스트 페이지</div>
+        </div>
+    );
+};

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,2 +1,2 @@
-export * from "./ui";
 export * from "./lib";
+export * from "./ui";

--- a/src/widgets/error/index.ts
+++ b/src/widgets/error/index.ts
@@ -1,0 +1,1 @@
+export { RouterErrorComponent } from "./ui/RouterErrorComponent";

--- a/src/widgets/error/ui/RootErrorModal.tsx
+++ b/src/widgets/error/ui/RootErrorModal.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+import { createPortal } from "react-dom";
+
+type Props = {
+    title: string;
+    message: string;
+};
+
+export const RootErrorModal = ({ title, message }: Props) => {
+    const [isOpen, setIsOpen] = useState(true);
+    useEffect(() => {
+        const timeKey = setTimeout(() => {
+            setIsOpen(false);
+        }, 1500);
+
+        return () => {
+            clearTimeout(timeKey);
+        };
+    }, []);
+    return (
+        isOpen &&
+        createPortal(
+            <div
+                style={{
+                    position: "absolute",
+                    left: "50%",
+                    top: "50%",
+                    transform: "translate(-50%, -50%)",
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    alignItems: "center",
+                }}
+            >
+                <div>{title}</div>
+                <div>{message}</div>
+            </div>,
+            document.body
+        )
+    );
+};

--- a/src/widgets/error/ui/RouterErrorComponent.tsx
+++ b/src/widgets/error/ui/RouterErrorComponent.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from "react-router-dom";
+
+type Props = {
+    message: string;
+};
+
+/** Router Error 발생 시 보여주는 컴포넌트 */
+export const RouterErrorComponent = ({ message }: Props) => {
+    const navigate = useNavigate();
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignItems: "center",
+                flex: 1,
+            }}
+        >
+            <div>{message}</div>
+            <div>
+                <button
+                    onClick={() => {
+                        navigate("/");
+                    }}
+                >
+                    홈으로 이동
+                </button>
+                <button
+                    onClick={() => {
+                        location.reload();
+                    }}
+                >
+                    새로 고침
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/src/widgets/example/index.ts
+++ b/src/widgets/example/index.ts
@@ -1,0 +1,1 @@
+export { ExampleFetchComponent } from "./ui/ExampleFetchComponent";

--- a/src/widgets/example/ui/ExampleFetchComponent.tsx
+++ b/src/widgets/example/ui/ExampleFetchComponent.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+import axios from "axios";
+
+type Props = {
+    isSuccess: boolean;
+};
+export const ExampleFetchComponent = ({ isSuccess }: Props) => {
+    const [data, setData] = useState<string>();
+    const [error, setError] = useState<Error>();
+    useEffect(() => {
+        const promise = axios.get("/");
+        const delay = async (promise: Promise<unknown>) => {
+            setData(
+                (() => {
+                    let status = "pending";
+                    setTimeout(() => {
+                        if (!isSuccess) {
+                            setError(new Error("테스트 에러"));
+                        }
+                        status = "success";
+                    }, 1000);
+                    return () => {
+                        if (status === "success") {
+                            return "hello";
+                        }
+                        throw promise;
+                    };
+                })()
+            );
+        };
+        delay(promise);
+    }, []);
+    useEffect(() => {
+        if (error) {
+            throw error;
+        }
+    }, [error]);
+
+    return <div>테스트 입니다2.{data}</div>;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 import react from "@vitejs/plugin-react";
 
-const filesExclude = [/^mock\//];
+const filesExclude = [/^mock\//, "src/app/router/DevRouter.tsx"];
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
### 기능
- 에러 바운더리 추가
- - Root Error Boundary
- - - Route, Fetch에서 못잡은 에러 캐치
- - Route Error Boundary
- - - Loader, Action에서 발생한 에러 캐치
- - Fetch Error Boundary
- - - 컴포넌트에서 발생한 에러 캐치
### 구조도
![image-20240804-105304](https://github.com/user-attachments/assets/95595b28-e31c-4dd7-81ce-c29cab19591b)


### 사용법
```
import { Suspense } from "react";

import { ExampleFetchComponent } from "@widgets/example";

import { FetchErrorBoundary } from "@entities/error";

export const ExampleSuccess = () => {
    return (
        <div>
            <div>테스트 페이지</div>
            <FetchErrorBoundary>
                <Suspense fallback={<div>로딩중...</div>}>
                    <비동기 통신 하는 컴포넌트/>
                </Suspense>
            </FetchErrorBoundary>
        </div>
    );
};

```
### 구현 화면
- 처음에 테스트입니다 부터 뜨는 이유는 useEffect로 비동기 했기 때문.
![qqq](https://github.com/user-attachments/assets/8c397491-d1ad-4801-b2ad-a185e3dce0b8)


