### PR TITLE
[feature] Portal 컴포넌트

### DIFF
--- a/src/shared/ui/Portal/Portal.tsx
+++ b/src/shared/ui/Portal/Portal.tsx
@@ -15,13 +15,13 @@ export type PortalProps = {
 };
 
 /**
+ * position은 anchorElement 기준으로 위치가 정해짐.
+ * container은 어느 컴포넌트에 portal을 띄울지 정하는 것.
+ * container, anchorElement모두 document.body가 기본값
  * @param zIndex ex) 일반 < 100 < 팝업 <1000 < 모달 < 모달 팝업
  * @param container 포탈을 생성할 위치
  * @param anchorEl 기준점이 될 Element.
  * @param position 기준점으로 부터 위치.
- * @description position은 anchorElement 기준으로 위치가 정해짐.
- * container은 어느 컴포넌트에 portal을 띄울지 정하는 것.
- * container, anchorElement모두 document.body가 기본값
  * @example
  * ()=> {
  * const anchorElement = useRef<HTMLElement>(null);
@@ -44,8 +44,9 @@ export const Portal = ({
     container,
     isAutoPosition = false,
 }: PortalProps) => {
-    /** zIndex === 0이면 layeredContainer는 documnet.body가 된다.
-     * zIndex !== 0이면 layeredContainer는 document.body에 추가된
+    /**
+     * zIndex === 0이면 layeredContainer는 documnet.body가 된다.
+     * zIndex !== 0이면 layeredContainer는 document.body에 추가된다.
      * <div id="layer-${zIndex}"></div>이 된다.
      */
     const { layeredChildren, layeredContainer } = usePortal({

--- a/src/shared/ui/Portal/Portal.tsx
+++ b/src/shared/ui/Portal/Portal.tsx
@@ -1,0 +1,61 @@
+import { ReactNode } from "react";
+
+import { createPortal } from "react-dom";
+
+import { usePortal } from "./hooks/useProtal";
+import { Position } from "./types";
+
+export type PortalProps = {
+    zIndex?: number;
+    container?: HTMLElement;
+    position?: Position;
+    anchorEl?: HTMLElement | null;
+    children: ReactNode;
+    isAutoPosition?: boolean;
+};
+
+/**
+ * @param zIndex ex) 일반 < 100 < 팝업 <1000 < 모달 < 모달 팝업
+ * @param container 포탈을 생성할 위치
+ * @param anchorEl 기준점이 될 Element.
+ * @param position 기준점으로 부터 위치.
+ * @description position은 anchorElement 기준으로 위치가 정해짐.
+ * container은 어느 컴포넌트에 portal을 띄울지 정하는 것.
+ * container, anchorElement모두 document.body가 기본값
+ * @example
+ * ()=> {
+ * const anchorElement = useRef<HTMLElement>(null);
+ * return (
+ *     <div ref={anchorElement}>
+ *         <Portal
+ *             zIndex={1}
+ *             anchorEl={anchorElement.current}
+ *             position={{ right:"0",top: "calc(100% + 10px)"}}>
+ *             <div>포탈로 띄울 컴포넌트</div>
+ *         </Portal>)
+ *     </div>
+ * }
+ */
+export const Portal = ({
+    zIndex,
+    children,
+    anchorEl,
+    position = { top: 0, left: 0 },
+    container,
+    isAutoPosition = false,
+}: PortalProps) => {
+    /** zIndex === 0이면 layeredContainer는 documnet.body가 된다.
+     * zIndex !== 0이면 layeredContainer는 document.body에 추가된
+     * <div id="layer-${zIndex}"></div>이 된다.
+     */
+    const { layeredChildren, layeredContainer } = usePortal({
+        zIndex,
+        children,
+        anchorEl: anchorEl ?? document.body,
+        position,
+        container: container ?? document.body,
+        isAutoPosition,
+    });
+
+    return createPortal(layeredChildren, layeredContainer);
+};

--- a/src/shared/ui/Portal/component/AutoPosition.tsx
+++ b/src/shared/ui/Portal/component/AutoPosition.tsx
@@ -1,0 +1,93 @@
+import { CSSProperties, PropsWithChildren, useLayoutEffect, useRef, useState } from "react";
+
+import { flushSync } from "react-dom";
+
+import { Position } from "../types";
+import { getPositionCss } from "../utils/getPositionCss";
+
+type AutoPositionProps = PropsWithChildren<{
+    container: HTMLElement;
+    anchorEl: HTMLElement;
+    position: Position;
+    isAutoPosition: boolean;
+}>;
+/**
+ * @description
+ * 컴포넌트 위치 계산해주고,
+ * isAutoPosition===true일 경우 Container 안으로 위치조정 하는 컴포넌트
+ */
+export const AutoPosition = ({
+    children,
+    anchorEl,
+    container,
+    position,
+    isAutoPosition,
+}: AutoPositionProps) => {
+    const throttlingKey = useRef<number | null>();
+    const displayElRef = useRef<HTMLDivElement>(null);
+    /** 컨테이너에 scroll 있을때, 스크롤 해도 위치를 고정시켜주는 역할. */
+    const { current: initialScroll } = useRef<{ x: number; y: number }>({
+        x: container.scrollLeft ?? 0,
+        y: container.scrollTop ?? 0,
+    });
+    const [style, setStyle] = useState<CSSProperties>();
+
+    useLayoutEffect(() => {
+        const displayEl = displayElRef.current;
+        if (!displayEl) throw new Error("ref에 연결된 element가 없습니다.");
+        /** ancchorEl, position에 따라서 알맞은 위치로 출력하도로 CSS 생성하는 함수.  */
+        const newStyle = getPositionCss({
+            position,
+            anchorEl,
+            container,
+            displayEl,
+            isAutoPosition,
+        });
+        setStyle(newStyle);
+        const handlePostion = () => {
+            // 쓰로틀링
+            if (!throttlingKey.current) {
+                throttlingKey.current = setTimeout(() => {
+                    /** 연산 우선순위 높여서 렉을 줄여준다. */
+                    requestAnimationFrame(() => {
+                        {
+                            const { x, y } = initialScroll;
+                            const xDiff = container.scrollLeft ?? 0;
+                            const yDiff = container.scrollTop ?? 0;
+                            // 순차 적용
+                            flushSync(() => {
+                                setStyle((prev) => ({
+                                    ...prev,
+                                    transform: `translate(${-xDiff + x}px, ${-yDiff + y}px)`,
+                                }));
+                            });
+                        }
+                    });
+                    throttlingKey.current = null;
+                }, 10);
+            }
+        };
+
+        if (container) container.addEventListener("scroll", handlePostion);
+        return () => {
+            if (container) container.removeEventListener("scroll", handlePostion);
+        };
+    }, [anchorEl, initialScroll, position, container, displayElRef, isAutoPosition]);
+
+    return (
+        <div
+            style={{ ...style }}
+            ref={displayElRef}
+            onClick={(e) => {
+                /** 원치않는 컴포넌트로 이벤트 전파 방지.
+                 * DOM트리 기준 이벤트 전파가 아닌, 리액트 트리기준 이벤트 전파이기 때문에,
+                 * body에 출력되어있더라도, Portal을 호출했던 컴포넌트로 이벤트 전파가 된다.
+                 * 따라서 해당 케이스로 사용하는 경우가 거의 없기때문에, 막아주는게 좋다.
+                 */
+                e.stopPropagation();
+            }}
+        >
+            {children}
+        </div>
+    );
+};

--- a/src/shared/ui/Portal/component/AutoPosition.tsx
+++ b/src/shared/ui/Portal/component/AutoPosition.tsx
@@ -12,7 +12,6 @@ type AutoPositionProps = PropsWithChildren<{
     isAutoPosition: boolean;
 }>;
 /**
- * @description
  * 컴포넌트 위치 계산해주고,
  * isAutoPosition===true일 경우 Container 안으로 위치조정 하는 컴포넌트
  */
@@ -79,7 +78,8 @@ export const AutoPosition = ({
             style={{ ...style }}
             ref={displayElRef}
             onClick={(e) => {
-                /** 원치않는 컴포넌트로 이벤트 전파 방지.
+                /**
+                 * 원치않는 컴포넌트로 이벤트 전파 방지.
                  * DOM트리 기준 이벤트 전파가 아닌, 리액트 트리기준 이벤트 전파이기 때문에,
                  * body에 출력되어있더라도, Portal을 호출했던 컴포넌트로 이벤트 전파가 된다.
                  * 따라서 해당 케이스로 사용하는 경우가 거의 없기때문에, 막아주는게 좋다.

--- a/src/shared/ui/Portal/hooks/useProtal.tsx
+++ b/src/shared/ui/Portal/hooks/useProtal.tsx
@@ -15,8 +15,7 @@ type UsePortalProps = {
 /**
  * @desciption
  * zIndex === 0이면 layeredContainer는 documnet.body가 된다.
- *
- * zIndex !== 0이면 layeredContainer는 document.body에 추가된
+ * zIndex !== 0이면 layeredContainer는 document.body에 추가된다.
  * <div id="layer-${zIndex}"></div>이 된다.
  */
 export const usePortal = ({
@@ -33,9 +32,10 @@ export const usePortal = ({
     );
 
     const { current: layeredChildren } = useRef<ReactNode>(
-        /** @description isAutopostion === true이면 출력 컴포넌트를
+        /**
+         * isAutopostion === true이면 출력 컴포넌트를
          * Container 내부로 강제로 컴포넌트 이동.
-         * */
+         */
         <AutoPosition
             position={position}
             anchorEl={anchorEl}

--- a/src/shared/ui/Portal/hooks/useProtal.tsx
+++ b/src/shared/ui/Portal/hooks/useProtal.tsx
@@ -1,0 +1,60 @@
+import { ReactNode, useEffect, useRef } from "react";
+
+import { AutoPosition } from "../component/AutoPosition";
+import { Position } from "../types";
+import { getContainer as getLayeredContainer } from "../utils/getContainer";
+
+type UsePortalProps = {
+    zIndex?: number;
+    position: Position;
+    anchorEl: HTMLElement;
+    children: ReactNode;
+    container: HTMLElement;
+    isAutoPosition: boolean;
+};
+/**
+ * @desciption
+ * zIndex === 0이면 layeredContainer는 documnet.body가 된다.
+ *
+ * zIndex !== 0이면 layeredContainer는 document.body에 추가된
+ * <div id="layer-${zIndex}"></div>이 된다.
+ */
+export const usePortal = ({
+    zIndex,
+    position,
+    anchorEl,
+    children,
+    container,
+    isAutoPosition,
+}: UsePortalProps) => {
+    /** z-index에 따른 계층화된 컨테이너 생성 또는 찾아오기. */
+    const { current: layeredContainer } = useRef<HTMLElement>(
+        getLayeredContainer(container, zIndex)
+    );
+
+    const { current: layeredChildren } = useRef<ReactNode>(
+        /** @description isAutopostion === true이면 출력 컴포넌트를
+         * Container 내부로 강제로 컴포넌트 이동.
+         * */
+        <AutoPosition
+            position={position}
+            anchorEl={anchorEl}
+            container={container}
+            isAutoPosition={isAutoPosition}
+        >
+            {children}
+        </AutoPosition>
+    );
+    useEffect(() => {
+        return () => {
+            /** 레이어에 children 없으면 레이어 삭제 */
+            if (!layeredContainer.children.length) {
+                layeredContainer.remove();
+            }
+        };
+    }, [children, layeredContainer]);
+    return {
+        layeredChildren,
+        layeredContainer,
+    };
+};

--- a/src/shared/ui/Portal/types/index.ts
+++ b/src/shared/ui/Portal/types/index.ts
@@ -1,0 +1,17 @@
+type Unit = "px" | "%";
+type Operator = "+" | "-" | "*" | "/";
+
+/** TODO: CSS 타입 지원하는 범위 늘려주기. 2024.08.25 윤동근*/
+export type PositionValue =
+    | number
+    | `${number}`
+    | `${number}${Unit}`
+    | `calc(${number}${Unit} ${Operator} ${number}${Unit})`
+    | `calc(${number}${Unit} ${Operator} ${number}${Unit} ${Operator} ${number}${Unit})`;
+
+export type Position = {
+    top?: PositionValue;
+    right?: PositionValue;
+    bottom?: PositionValue;
+    left?: PositionValue;
+};

--- a/src/shared/ui/Portal/utils/getContainer.ts
+++ b/src/shared/ui/Portal/utils/getContainer.ts
@@ -1,9 +1,10 @@
-/** zIndex가 없으면 container가 그대로 Container가 됨.
- *
+/**
+ * zIndex가 없으면 container가 그대로 Container가 됨.
  * zIndex가 있으면 container에 Layer를 추가하고 해당 div가 Container가 됨.
  */
 export const getContainer = (container: HTMLElement, zIndex?: number) => {
-    /** id===layer-${zIndex}인 컴포넌트 있으면 찾기.
+    /**
+     * id===layer-${zIndex}인 컴포넌트 있으면 찾기.
      * TODO: container가 다를경우 id값에 prefix로 추가해주기. 2024.08.26 윤동근
      */
     let layeredContainer = zIndex ? document.getElementById(`layer-${zIndex}`) : container;

--- a/src/shared/ui/Portal/utils/getContainer.ts
+++ b/src/shared/ui/Portal/utils/getContainer.ts
@@ -1,0 +1,23 @@
+/** zIndex가 없으면 container가 그대로 Container가 됨.
+ *
+ * zIndex가 있으면 container에 Layer를 추가하고 해당 div가 Container가 됨.
+ */
+export const getContainer = (container: HTMLElement, zIndex?: number) => {
+    /** id===layer-${zIndex}인 컴포넌트 있으면 찾기.
+     * TODO: container가 다를경우 id값에 prefix로 추가해주기. 2024.08.26 윤동근
+     */
+    let layeredContainer = zIndex ? document.getElementById(`layer-${zIndex}`) : container;
+    /** id===layer-${zIndex}인 컴포넌트 없으면, 추가해주고, 해당 컴포넌트 return 한다. */
+    if (!layeredContainer) {
+        const containerElement = document.createElement("div");
+        containerElement.style.zIndex = zIndex ? zIndex.toString() : "";
+        containerElement.style.position = "absolute";
+        containerElement.style.left = "0";
+        containerElement.style.top = "0";
+        containerElement.id = `layer-${zIndex}`;
+        containerElement.role = "presentation";
+        layeredContainer = containerElement;
+        container.appendChild(layeredContainer);
+    }
+    return layeredContainer;
+};

--- a/src/shared/ui/Portal/utils/getPositionCss.ts
+++ b/src/shared/ui/Portal/utils/getPositionCss.ts
@@ -10,9 +10,10 @@ type GetChildrenPositionProps = {
     isAutoPosition: boolean;
 };
 /**
+ * CssString에서 Pixel값 number로 뽑아오는 함수.
  * @param lengthFromAnchor Anchor Element로부터의 거리 cssString
  * @param anchorWidthOrHeight cssString이 %일 경우, anchorWidthOrHeight를 기준으로 계산.
- * CssString에서 Pixel값 number로 뽑아오는 함수. */
+ * */
 const getPixelFromCssString = (lengthFromAnchor: string, anchorWidthOrHeight: number) => {
     const endIndex = lengthFromAnchor.match(/[+\-*/x%]/)?.index ?? lengthFromAnchor.length - 1;
     switch (lengthFromAnchor[endIndex]) {
@@ -27,8 +28,8 @@ const getPixelFromCssString = (lengthFromAnchor: string, anchorWidthOrHeight: nu
     }
 };
 /**
- * @param {number} anchorPosition  절대 위치로 px 단위
- * @param {number} lengthFromAnchor anchor로 부터 거리 px 단위
+ * @param anchorPosition  절대 위치로 px 단위
+ * @param lengthFromAnchor anchor로 부터 거리 px 단위
  * */
 const getPosition = (
     lengthFromAnchor: PositionValue,
@@ -135,9 +136,7 @@ export const getPositionCss = ({
         typeof rightFromAnchor !== "undefined"
             ? right * 2 - getPosition(rightFromAnchor, right, width) - dWidth
             : undefined;
-    /**
-     *  초기 렌더링시 컨테이너 밖으로 못나가도록 계산.
-     */
+    /** 초기 렌더링시 컨테이너 밖으로 못나가도록 계산. */
     if (isAutoPosition) {
         if (calculatedLeft && calculatedLeft + dWidth < cRight) {
             calculatedLeft = cRight - dWidth;

--- a/src/shared/ui/Portal/utils/getPositionCss.ts
+++ b/src/shared/ui/Portal/utils/getPositionCss.ts
@@ -1,0 +1,162 @@
+import { CSSProperties } from "react";
+
+import { Position, PositionValue } from "../types";
+
+type GetChildrenPositionProps = {
+    position: Position;
+    anchorEl: HTMLElement;
+    container: HTMLElement;
+    displayEl: HTMLElement;
+    isAutoPosition: boolean;
+};
+/**
+ * @param lengthFromAnchor Anchor Element로부터의 거리 cssString
+ * @param anchorWidthOrHeight cssString이 %일 경우, anchorWidthOrHeight를 기준으로 계산.
+ * CssString에서 Pixel값 number로 뽑아오는 함수. */
+const getPixelFromCssString = (lengthFromAnchor: string, anchorWidthOrHeight: number) => {
+    const endIndex = lengthFromAnchor.match(/[+\-*/x%]/)?.index ?? lengthFromAnchor.length - 1;
+    switch (lengthFromAnchor[endIndex]) {
+        case "%":
+            return (parseInt(lengthFromAnchor) * anchorWidthOrHeight) / 100;
+        case "x":
+            return parseInt(lengthFromAnchor);
+        case ")":
+            return parseInt(lengthFromAnchor);
+        default:
+            return parseInt(lengthFromAnchor);
+    }
+};
+/**
+ * @param {number} anchorPosition  절대 위치로 px 단위
+ * @param {number} lengthFromAnchor anchor로 부터 거리 px 단위
+ * */
+const getPosition = (
+    lengthFromAnchor: PositionValue,
+    anchorPosition: number,
+    anchorWidthOrHeight: number
+) => {
+    if (typeof lengthFromAnchor === "number") return anchorPosition + lengthFromAnchor;
+    parseCalc(lengthFromAnchor, anchorWidthOrHeight);
+    return (
+        anchorPosition +
+        (lengthFromAnchor.startsWith("calc")
+            ? parseCalc(lengthFromAnchor, anchorWidthOrHeight)
+            : getPixelFromCssString(lengthFromAnchor, anchorWidthOrHeight))
+    );
+};
+
+/** TODO : pop으로 연산하는 알고리즘 적용하기. 2024-08-25 윤동근*/
+const parseCalc = (lengthFromAnchor: string, anchorWidthOrHeight: number) => {
+    const parsedLengthFromAnchor = lengthFromAnchor
+        .replace(/\s+/g, "")
+        .replace(/.*\(([^)]+)\).*/, "$1");
+    const ValueWithDelimiterIndex = parsedLengthFromAnchor.matchAll(/[+\-*/]/g);
+    let calculatedValue = getPixelFromCssString(parsedLengthFromAnchor, anchorWidthOrHeight);
+    for (const aValueWithDelimiter of ValueWithDelimiterIndex) {
+        const delimiterIndex = aValueWithDelimiter.index;
+        const delimiter = parsedLengthFromAnchor[delimiterIndex];
+        switch (delimiter) {
+            case "+":
+                calculatedValue += getPixelFromCssString(
+                    parsedLengthFromAnchor.slice(delimiterIndex + 1, parsedLengthFromAnchor.length),
+                    anchorWidthOrHeight
+                );
+
+                break;
+            case "-":
+                calculatedValue -= getPixelFromCssString(
+                    parsedLengthFromAnchor.slice(delimiterIndex + 1, parsedLengthFromAnchor.length),
+                    anchorWidthOrHeight
+                );
+                break;
+            case "*":
+                calculatedValue *= getPixelFromCssString(
+                    parsedLengthFromAnchor.slice(delimiterIndex + 1, parsedLengthFromAnchor.length),
+                    anchorWidthOrHeight
+                );
+                break;
+            default:
+                calculatedValue /= getPixelFromCssString(
+                    parsedLengthFromAnchor.slice(delimiterIndex + 1, parsedLengthFromAnchor.length),
+                    anchorWidthOrHeight
+                );
+                break;
+        }
+    }
+    return calculatedValue;
+};
+
+export const getPositionCss = ({
+    position,
+    anchorEl,
+    container,
+    displayEl,
+    isAutoPosition,
+}: GetChildrenPositionProps) => {
+    // 사용자 설정 위치
+    const {
+        top: topFromAnchor,
+        right: rightFromAnchor,
+        left: leftFromAnchor,
+        bottom: bottomFromAnchor,
+    } = position;
+    // Anchor Element 위치
+    const { left, top, bottom, right, width, height } = anchorEl.getBoundingClientRect();
+    // Container 위치
+    const {
+        left: cLeft,
+        top: cTop,
+        right: cRight,
+        bottom: cBottom,
+        height: cHeight,
+        width: cWidth,
+    } = container.getBoundingClientRect();
+    // Displayed Element 너비, 높이
+    const { width: dWidth, height: dHeight } = displayEl.getBoundingClientRect();
+    let {
+        calculatedTop,
+        calculatedLeft,
+        calculatedBottom,
+        calculatedRight,
+    }: Record<string, number | undefined> = {};
+    calculatedTop =
+        typeof topFromAnchor !== "undefined"
+            ? getPosition(topFromAnchor, top, height)
+            : topFromAnchor;
+    calculatedLeft =
+        typeof leftFromAnchor !== "undefined"
+            ? getPosition(leftFromAnchor, left, width)
+            : undefined;
+    calculatedBottom =
+        typeof bottomFromAnchor !== "undefined"
+            ? bottom * 2 - getPosition(bottomFromAnchor, bottom, height) - dHeight
+            : undefined;
+    calculatedRight =
+        typeof rightFromAnchor !== "undefined"
+            ? right * 2 - getPosition(rightFromAnchor, right, width) - dWidth
+            : undefined;
+    /**
+     *  초기 렌더링시 컨테이너 밖으로 못나가도록 계산.
+     */
+    if (isAutoPosition) {
+        if (calculatedLeft && calculatedLeft + dWidth < cRight) {
+            calculatedLeft = cRight - dWidth;
+        }
+        if (calculatedTop && calculatedTop + dHeight > cBottom) {
+            calculatedTop = cBottom - dHeight;
+        }
+        if (calculatedRight && calculatedRight - dWidth < cLeft) {
+            calculatedRight = cWidth - dWidth;
+        }
+        if (calculatedBottom && calculatedBottom - dHeight < cTop) {
+            calculatedBottom = cHeight + dHeight;
+        }
+    }
+
+    const cssProps: CSSProperties = {
+        top: calculatedTop ?? calculatedBottom,
+        left: calculatedLeft ?? calculatedRight,
+        position: "relative",
+    };
+    return cssProps;
+};

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -3,3 +3,4 @@ export { media } from "./theme/media";
 export { Layout } from "./Layout/Layout";
 export { CountryFlag, type TCountryName } from "./CountryFlag/CountryFlag";
 export { Select } from "./Select/Select";
+export { Portal } from "./Portal/Portal";


### PR DESCRIPTION
### 추가 컴포넌트
- Portal 컴포넌트 추가
### 이점
- 부모 컴포넌트의  Postion, Overflow 속성 신경쓰지 않아도 됨.
- 부모, 자식 컴포넌트에서 EventPropagation을 막아야 하는 Case가 사라짐.

### 사용법
```tsx
 const MyComponent= ()=> {
 // anchorElement 없을경우, document.body가 position 기준.

 const anchorElement = useRef<HTMLElement>(null);
return (
     <div ref={anchorElement}>
{/*  z-index ===0인 경우, document.body에 바로추가 */}
{/*  z-index !==0인 경우, document.body에 id="layer-${z-index}"인 div 생성 후, 해당 div에 추가 */}
         <Portal
             zIndex={1}
             anchorEl={anchorElement.current}
             position={{ right:"0",top: "calc(100% + 10px)"}}>
             <div>포탈로 띄울 컴포넌트</div>
         </Portal>)
     </div>
 }
```