### PR TITLE
[refactor] i18n 타입 정의 및 폴더 구조 변경

### DIFF
--- a/src/features/i18n/en.ts
+++ b/src/features/i18n/en.ts
@@ -1,5 +1,0 @@
-import { I18_EXAMPLE } from "./enExample";
-
-export const en = {
-    I18_EXAMPLE,
-};

--- a/src/features/i18n/en/common.ts
+++ b/src/features/i18n/en/common.ts
@@ -1,0 +1,9 @@
+export const common = {
+    GNB: {
+        Home: "Home",
+        Explore: "Explore",
+        Matches: "Matches",
+        Community: "Community",
+        SignInBtn: "SignInBtn",
+    },
+} as const;

--- a/src/features/i18n/en/en.translation.ts
+++ b/src/features/i18n/en/en.translation.ts
@@ -1,0 +1,7 @@
+import { common } from "./common";
+import { home } from "./home";
+
+export const en = {
+    common,
+    home,
+} as const;

--- a/src/features/i18n/en/home.ts
+++ b/src/features/i18n/en/home.ts
@@ -1,0 +1,9 @@
+export const home = {
+    MainTitle: "EVERYTHING STARTS WITH\nCHIT A CHAT",
+    SubTitle:
+        "Are you looking for someone to share common interests with?\nDiscover meaningful connections and build strong bonds at CHIT A CHAT.",
+    TotalMember: "Total Members",
+    TotalMatche: "Total Matches",
+    TotalLikes: "Number of likes",
+    MainButton: "Find your match",
+} as const;

--- a/src/features/i18n/enExample.ts
+++ b/src/features/i18n/enExample.ts
@@ -1,3 +1,0 @@
-export const I18_EXAMPLE = {
-    I18_EXAMPLE: "english example",
-};

--- a/src/features/i18n/i18n.d.ts
+++ b/src/features/i18n/i18n.d.ts
@@ -1,0 +1,11 @@
+import "i18next";
+
+import { en } from "./en/en.translation";
+
+type TResources = typeof en;
+declare module "i18next" {
+    interface CustomTypeOptions {
+        /** 자동완성을 위한 정의 */
+        resources: TResources;
+    }
+}

--- a/src/features/i18n/index.ts
+++ b/src/features/i18n/index.ts
@@ -1,12 +1,12 @@
 import { initReactI18next } from "react-i18next";
 
-import i18n from "i18next";
+import i18n, { CustomTypeOptions } from "i18next";
 
-import { en } from "./en";
-import { ko } from "./ko";
+import { en } from "./en/en.translation";
+import { ko } from "./ko/ko.translation";
 
-export const defaultNS = "translation";
-export const resources = { ko, en };
+const defaultNS: keyof CustomTypeOptions["resources"] = "common";
+const resources = { ko, en };
 
 i18n.use(initReactI18next).init({
     lng: localStorage.getItem("language") || "ko",

--- a/src/features/i18n/ko.ts
+++ b/src/features/i18n/ko.ts
@@ -1,5 +1,0 @@
-import { I18_EXAMPLE } from "./koExample";
-
-export const ko = {
-    I18_EXAMPLE,
-};

--- a/src/features/i18n/ko/common.ts
+++ b/src/features/i18n/ko/common.ts
@@ -1,0 +1,9 @@
+export const common = {
+    GNB: {
+        Home: "홈",
+        Explore: "둘러보기",
+        Matches: "매칭공간",
+        Community: "커뮤니티",
+        SignInBtn: "로그인",
+    },
+} as const;

--- a/src/features/i18n/ko/home.ts
+++ b/src/features/i18n/ko/home.ts
@@ -1,0 +1,9 @@
+export const home = {
+    MainTitle: "모든 만남은 CHIT A CHAT\n에서 시작된다!",
+    SubTitle:
+        "공통의 관심사를 나눌 수 있는 사람을 찾고 계신가요? CHIT A CHAT에서 깊은 인연을 만들고, 공감대를 형성할 수 있는 만남을 탐색해보세요! 즐거운 시간을 위해 CHIT A CHAT이 함께합니다!",
+    TotalMember: "전체 멤버 수",
+    TotalMatche: "전체 만남 횟수",
+    TotalLikes: "좋아요 보낸 수",
+    MainButton: "만남을 시작해보세요",
+} as const;

--- a/src/features/i18n/ko/ko.translation.ts
+++ b/src/features/i18n/ko/ko.translation.ts
@@ -1,0 +1,13 @@
+import { en } from "../en/en.translation";
+import { common } from "./common";
+import { home } from "./home";
+
+/** Object Key값들만 가져와 타입 만드는 타입 유틸. */
+type TEqualKeyObject<T> = {
+    [K in keyof T]: T[K] extends object ? TEqualKeyObject<T[K]> : unknown;
+};
+/** TEqualKeyObject를 이용하여 en 번역의 Key값들과 일치하도록 만들게 강제하기. */
+export const ko: TEqualKeyObject<typeof en> = {
+    common,
+    home,
+} as const;

--- a/src/features/i18n/koExample.ts
+++ b/src/features/i18n/koExample.ts
@@ -1,3 +1,0 @@
-export const I18_EXAMPLE = {
-    I18_EXAMPLE: "한국어 예시",
-};


### PR DESCRIPTION
### 변경 사항
- i18n 타입 정의
- 폴더 구조 변경
- 사용 예시 홈 화면으로 예시로 추가 

### 변경 사유
- 자동 완성을 위한 타입 정의
- 여러 페이지의 번역 파일을 만들기 때문에 하위 폴더 추가. (en, ko 폴더) 